### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned to v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,3 +100,9 @@ The OpenAPI spec is generated at runtime by `OpenApiDocumentGenerator` (using `M
 - OpenAPI spec generated at runtime by `OpenApiDocumentGenerator` (reflection-based), served at `/api/openapi/v1.json`
 - `ApiInfo` function at `/api/v1/info` returns assembly version for deploy verification
 - See `docs/development-workflows.md` for branch strategy and CI/CD flow details
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -42,3 +43,14 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo is wired to the `frasermolyneux-copilot` MCP server (catalog of org instructions/prompts/agents). The coding-agent config lives at `.github/copilot/mcp_config.json`; `.github/workflows/copilot-setup-steps.yml` checks out `frasermolyneux/.github-copilot@v0.1.0` and builds the stdio server. See `.github-copilot/mcp-server/README.md` (in the checked-out catalog repo) for the full tool contract and local client wire-up snippets.


### PR DESCRIPTION
Wires this repo to the `frasermolyneux-copilot` MCP server so MCP-capable agents (VS Code Copilot Chat, the GitHub Copilot coding agent, Copilot CLI, etc.) can query the org's instruction/prompt/agent catalog at `frasermolyneux/.github-copilot` directly, rather than relying solely on file-load. Matches the pattern already merged in `portal-core`.

## Changes

- **`.github/workflows/copilot-setup-steps.yml`** — pin the existing `frasermolyneux/.github-copilot` checkout to `refs/tags/v0.1.0` (was previously unpinned), then append `actions/setup-node@v6` (Node 20.x) and a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`). Existing `.NET` setup preserved.
- **`.github/copilot/mcp_config.json`** (new) — declares the local stdio MCP server for the GitHub Copilot coding agent.
- **`.github/copilot-instructions.md`** — appends the canonical "Org conventions via MCP (when available)" section so agents know to prefer MCP tools when a server is wired in. The snippet is byte-identical to the source-of-truth in `frasermolyneux/.github-copilot` (SHA256 `F14B266487487AC58B8E31CB59A4B62F8BC4D2AE00930C4DE763D8EB6EB50C33`).
- **`README.md`** — short `Local dev: MCP wire-up` section pointing at `.github-copilot/mcp-server/README.md` for the full tool contract.

## Notes for reviewers

- The snippet is intentionally conditional ("when available") so it's a no-op for clients without an MCP server configured.
- `AGENTS.md` is not present in this repo, so the parallel `AGENTS.md` insertion from the template is deferred to a separate metadata bootstrap. The 4 files above are the applicable subset for this repo's current state.
- Pre-existing observation: the `.github-copilot` checkout in `copilot-setup-steps.yml` was previously unpinned. This PR adds the `v0.1.0` pin as part of the wire-up.